### PR TITLE
Add endpoint to fetch by symbol and service

### DIFF
--- a/src/Blockcore.Dns/Api/DnsController.cs
+++ b/src/Blockcore.Dns/Api/DnsController.cs
@@ -51,6 +51,12 @@ namespace Blockcore.Dns.Api
             return new OkObjectResult(domainService.DomainServiceEntries.Select(s => s.ToString()));
         }
 
+        [HttpGet("services/{symbol}/{service}")]
+        public IActionResult ServiceEntries(string? symbol, string? service)
+        {
+            return new OkObjectResult(domainService.GetDomainData(symbol,service));
+        }
+
         [HttpGet("ipaddress")]
         public IActionResult IpAddress()
         {

--- a/src/Blockcore.Dns/Api/DnsController.cs
+++ b/src/Blockcore.Dns/Api/DnsController.cs
@@ -45,16 +45,34 @@ namespace Blockcore.Dns.Api
             return new OkObjectResult(domainService.DnsServiceEntries.Select(s => s.ToString()));
         }
 
-        [HttpGet("services")]
-        public IActionResult ServiceEntries()
+        [HttpGet("domains")]
+        public IActionResult ServiceEntriesAll()
         {
             return new OkObjectResult(domainService.DomainServiceEntries.Select(s => s.ToString()));
         }
 
-        [HttpGet("services/{symbol}/{service}")]
-        public IActionResult ServiceEntries(string? symbol, string? service)
+        [HttpGet("services")]
+        public IActionResult ServiceEntries()
         {
-            return new OkObjectResult(domainService.GetDomainData(symbol,service));
+            return new OkObjectResult(domainService.GetDomainData(null, null));
+        }
+
+        [HttpGet("services/symbol/{symbol}")]
+        public IActionResult ServiceEntriesSymbols(string symbol)
+        {
+            return new OkObjectResult(domainService.GetDomainData(symbol, null));
+        }
+
+        [HttpGet("services/service/{service}")]
+        public IActionResult ServiceEntriesService(string service)
+        {
+            return new OkObjectResult(domainService.GetDomainData(null, service));
+        }
+
+        [HttpGet("services/symbol/{symbol?}/service/{service?}")]
+        public IActionResult ServiceEntries(string symbol, string service)
+        {
+            return new OkObjectResult(domainService.GetDomainData(symbol, service));
         }
 
         [HttpGet("ipaddress")]

--- a/src/Blockcore.Dns/DnsResult.cs
+++ b/src/Blockcore.Dns/DnsResult.cs
@@ -1,0 +1,15 @@
+﻿using DNS.Protocol.Utils;
+
+namespace Blockcore.Dns
+{
+    public class DnsResult
+    {
+        public string Domain { get; set; }
+        public string IpAddress { get; set; }
+        public int Port { get; set; }
+        public int SecurePort { get; set; }
+        public string Symbol { get; set; }
+        public string Service { get; set; }
+        public int Ttl { get; set; }
+    }
+}

--- a/src/Blockcore.Dns/DnsResult.cs
+++ b/src/Blockcore.Dns/DnsResult.cs
@@ -5,11 +5,9 @@ namespace Blockcore.Dns
     public class DnsResult
     {
         public string Domain { get; set; }
-        public string IpAddress { get; set; }
-        public int Port { get; set; }
-        public int SecurePort { get; set; }
         public string Symbol { get; set; }
         public string Service { get; set; }
         public int Ttl { get; set; }
+        public bool Online { get; set; }
     }
 }

--- a/src/Blockcore.Dns/DomainService.cs
+++ b/src/Blockcore.Dns/DomainService.cs
@@ -65,12 +65,10 @@ public class DomainService : IDomainService, IRequestResolver
         return items.Select(s => new DnsResult
         {
             Domain = s.DnsRequest.Domain,
-            IpAddress = s.DnsRequest.IpAddress,
-            Port = s.DnsRequest.Port,
-            SecurePort = s.DnsRequest.SecurePort,
             Service = s.DnsRequest.Service,
             Symbol = s.DnsRequest.Symbol,
             Ttl = s.DnsRequest.Ttl,
+            Online = s.FailedPings == 0
         }).ToList();
     }
 

--- a/src/Blockcore.Dns/DomainService.cs
+++ b/src/Blockcore.Dns/DomainService.cs
@@ -38,6 +38,42 @@ public class DomainService : IDomainService, IRequestResolver
         this.logger = logger;
     }
 
+    public IList<DnsResult> GetDomainData(string? symbol, string? service)
+    {
+        var entries = domainServiceEntries;
+        var values = entries.Values.AsEnumerable();
+
+        IEnumerable<DomainServiceEntry> items = Enumerable.Empty<DomainServiceEntry>();
+
+        if (!string.IsNullOrEmpty(symbol) && !string.IsNullOrEmpty(service))
+        {
+            items = values.Where(entry => entry.DnsRequest.Symbol == symbol && entry.DnsRequest.Service == service);
+        }
+        else if (!string.IsNullOrEmpty(symbol))
+        {
+            items = values.Where(entry => entry.DnsRequest.Symbol == symbol);
+        }
+        else if (!string.IsNullOrEmpty(service))
+        {
+            items = values.Where(entry => entry.DnsRequest.Service == service);
+        }
+        else
+        {
+            items = values;
+        }
+
+        return items.Select(s => new DnsResult
+        {
+            Domain = s.DnsRequest.Domain,
+            IpAddress = s.DnsRequest.IpAddress,
+            Port = s.DnsRequest.Port,
+            SecurePort = s.DnsRequest.SecurePort,
+            Service = s.DnsRequest.Service,
+            Symbol = s.DnsRequest.Symbol,
+            Ttl = s.DnsRequest.Ttl,
+        }).ToList();
+    }
+
     public Task<IResponse> Resolve(IRequest request, CancellationToken cancellationToken = default)
     {
         var entries = domainServiceEntries;

--- a/src/Blockcore.Dns/IDomainService.cs
+++ b/src/Blockcore.Dns/IDomainService.cs
@@ -10,5 +10,7 @@ namespace Blockcore.Dns
 
         bool TryAddRecord(DnsData dnsRequest);
         bool TryRemoveRecord(DomainServiceEntry serviceEntry);
+
+        IList<DnsResult> GetDomainData(string? symbol, string? service);
     }
 }


### PR DESCRIPTION
In preparation to fetching dns data from the explorer and wallet we need to expose filter by symbol and service